### PR TITLE
Remove sudo from can0 status check command

### DIFF
--- a/src/nhk2026_bridge/launch/nhk2026_can.launch.py
+++ b/src/nhk2026_bridge/launch/nhk2026_can.launch.py
@@ -43,7 +43,7 @@ def _run_cmd(cmd):
 def _ensure_can0_up(context, *args, **kwargs):
     # can0 があるかチェック
     try:
-        out = subprocess.check_output(["sudo", "/usr/sbin/ip", "-details", "link", "show", "can0"], text=True)
+        out = subprocess.check_output(["/usr/sbin/ip", "-details", "link", "show", "can0"], text=True)
     except Exception:
         # can0 が無い/読めないなら何もしない
         return []


### PR DESCRIPTION
Eliminate the use of sudo in the command that checks the status of can0, simplifying the execution and improving accessibility.